### PR TITLE
Add spellcheck workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,16 @@
+name: Spellcheck
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+    # The checkout step
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: rojopolis/spellcheck-github-actions@3ac4dc4e6dffa64c3608272a8d2c24da9fa951a6
+      name: Spellcheck
+      with:
+        config_path: config/spellcheck.yml 

--- a/config/spellcheck.yml
+++ b/config/spellcheck.yml
@@ -1,0 +1,16 @@
+matrix:
+- name: Markdown
+  aspell:
+    lang: en
+  dictionary:
+    encoding: utf-8
+  pipeline:
+  - pyspelling.filters.markdown:
+  - pyspelling.filters.html:
+      comments: false
+      ignores:
+      - code
+      - pre
+  sources:
+  - '**/*.md'
+  default_encoding: utf-8


### PR DESCRIPTION
This workflow will do a spellcheck on any markdown content included in pull requests against `main`. This can be added as a required check in our rulesets with the following after it is merged:

<img width="766" height="379" alt="image" src="https://github.com/user-attachments/assets/514ab62a-c30c-490b-86f4-b1c4eb402662" />

We will likely want to curate a wordlist of exceptions before using this as a _required_ check. Once we have that, we can add it in `config/spellcheck.yml` as (for example):

```
    wordlists:
    - .wordlist.txt
```