### PR TITLE
 Fix author names not displaying on article pages

### DIFF
--- a/content/about/about-us.md
+++ b/content/about/about-us.md
@@ -1,7 +1,7 @@
 ---
 title: "About Us"
 date: 2020-01-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/about/charter.md
+++ b/content/about/charter.md
@@ -1,7 +1,7 @@
 ---
 title: "Charter"
 date: 2020-01-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/about/meeting-log.md
+++ b/content/about/meeting-log.md
@@ -1,7 +1,7 @@
 ---
 title: "Meeting Log"
 date: 2020-01-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/about/membership-pledge.md
+++ b/content/about/membership-pledge.md
@@ -1,7 +1,7 @@
 ---
 title: "Membership Pledge"
 date: 2025-07-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/about/non-disclosure-agreement.md
+++ b/content/about/non-disclosure-agreement.md
@@ -1,7 +1,7 @@
 ---
 title: "Non-Disclosure Agreement"
 date: 2025-08-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/about/privacy-policy.md
+++ b/content/about/privacy-policy.md
@@ -1,7 +1,7 @@
 ---
 title: "Privacy Policy"
 date: 2020-01-01
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/framework/chapter-1.md
+++ b/content/framework/chapter-1.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 1: What is a Bug Bounty Program?"
 date: 2021-05-04
-authors: [
+author: [
     "Deana Shick", 
     "Johnathan Kuskos", 
     "Kathleen Trimble-Noble"

--- a/content/framework/chapter-2.md
+++ b/content/framework/chapter-2.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 2: Is a Bug Bounty Program Right for You?"
 date: 2021-06-23
-authors: [
+author: [
   "Sean Poris",
   "Johnathan Kuskos",
   "Josh Dembling",

--- a/content/framework/chapter-3.md
+++ b/content/framework/chapter-3.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 3: Charter Your Program & Set Strategic Objectives"
 date: 2021-07-28
-authors: [
+author: [
     "Anil Dewan",
     "Annika Erickson",
     "Kathleen Trimble-Noble",

--- a/content/framework/chapter-4.md
+++ b/content/framework/chapter-4.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 4: Scope and Budget"
 date: 2021-09-07
-authors: [
+author: [
   "Anil Dewan",
   "Annika Erickson",
   "Kathleen Trimble-Noble",

--- a/content/framework/chapter-5.md
+++ b/content/framework/chapter-5.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 5: All Things Payment"
 date: 2024-05-13
-authors: [
+author: [
   "Logan MacLaren",
   "Deana Shick",
   "Christopher Robinson",

--- a/content/framework/chapter-6.md
+++ b/content/framework/chapter-6.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapter 6: Handling Disputes"
 date: 2024-07-22
-authors: [
+author: [
   "Logan MacLaren",
   "Chris Holt",
   "Adam Bacchus"

--- a/content/framework/drafts/legal-compliance.md
+++ b/content/framework/drafts/legal-compliance.md
@@ -3,7 +3,7 @@ title: "Legal and Compliance Considerations"
 date: 2025-05-30
 chapter: 5
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 weight: 50
 summary: "Essential legal and compliance guidelines for bug bounty programs, including safe harbor provisions, disclosure policies, and regulatory considerations."

--- a/content/framework/drafts/metrics-reporting.md
+++ b/content/framework/drafts/metrics-reporting.md
@@ -3,7 +3,7 @@ title: "Metrics and Reporting"
 date: 2025-05-30
 chapter: 6
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 weight: 60
 summary: "Comprehensive guide to measuring, analyzing, and reporting bug bounty program performance, including key metrics, dashboards, and stakeholder communications."

--- a/content/framework/drafts/program-management.md
+++ b/content/framework/drafts/program-management.md
@@ -3,7 +3,7 @@ title: "Bug Bounty Program Management"
 date: 2025-05-30
 chapter: 1
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 summary: "A comprehensive framework for managing bug bounty programs effectively, covering scope definition, reward structures, triage processes, and program metrics."
 ---

--- a/content/framework/drafts/researcher-engagement.md
+++ b/content/framework/drafts/researcher-engagement.md
@@ -3,7 +3,7 @@ title: "Researcher Engagement and Communication"
 date: 2025-05-30
 chapter: 3
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 weight: 30
 summary: "Best practices for engaging with security researchers, including communication guidelines, recognition programs, and building a positive research community."

--- a/content/framework/drafts/security-testing.md
+++ b/content/framework/drafts/security-testing.md
@@ -3,7 +3,7 @@ title: "Security Testing Guidelines"
 date: 2025-05-30
 chapter: 4
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 weight: 40
 summary: "Comprehensive guidelines for security testing in bug bounty programs, including testing methodologies, tools, and best practices for responsible disclosure."

--- a/content/framework/drafts/vulnerability-classification.md
+++ b/content/framework/drafts/vulnerability-classification.md
@@ -3,7 +3,7 @@ title: "Vulnerability Classification and Scoring"
 date: 2025-05-30
 chapter: 2
 version: "1.0"
-authors: ["BBCOI"]
+author: ["BBCOI"]
 draft: true
 weight: 20
 summary: "A standardized approach to classifying and scoring vulnerabilities in bug bounty programs, including severity assessment and impact analysis."

--- a/content/posts/Test.md
+++ b/content/posts/Test.md
@@ -1,7 +1,7 @@
 ---
 title: "Test of all the tests"
 date: 2024-08-16
-authors: [
+author: [
   "Lady_N"
 ]
 tags: [

--- a/content/posts/ai-in-bug-bounty-platforms-evolution-or-exploitation.md
+++ b/content/posts/ai-in-bug-bounty-platforms-evolution-or-exploitation.md
@@ -1,7 +1,7 @@
 ---
 title: "AI in Bug Bounty Platforms: Evolution or Exploitation?"
 date: 2025-09-26
-authors: [
+author: [
   "bbcoi"
   ]
 tags: [

--- a/content/posts/call-a-duck-a-duck-not-a-bug-bounty.md
+++ b/content/posts/call-a-duck-a-duck-not-a-bug-bounty.md
@@ -1,7 +1,7 @@
 ---
 title: "Call a Duck a Duck, not a Bug Bounty"
 date: 2020-09-28
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/posts/case-study-intel-retest-strategy.md
+++ b/content/posts/case-study-intel-retest-strategy.md
@@ -1,7 +1,7 @@
 ---
 title: "Case Study: How Intel is Challenging the Norms of Bug Bounty Retesting"
 date: 2024-08-16
-authors: [
+author: [
   "Chris Holt"
 ]
 tags: [

--- a/content/posts/effective-communication-goes-a-long-way.md
+++ b/content/posts/effective-communication-goes-a-long-way.md
@@ -1,7 +1,7 @@
 ---
 title: "Effective Communication Goes a Long Way"
 date: 2020-12-10
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [

--- a/content/posts/response-practitioners-take-on-econ.md
+++ b/content/posts/response-practitioners-take-on-econ.md
@@ -2,7 +2,7 @@
 title: "Response: A Practitioner’s Take on Economic Taxonomy of Vulnerabilities"
 date: 2026-02-09
 draft: false
-authors: [
+author: [
   “bbcoi”,
   "Chris Holt",
   "Marc Druzin"

--- a/content/posts/the-imperative-of-inclusion.md
+++ b/content/posts/the-imperative-of-inclusion.md
@@ -1,7 +1,7 @@
 ---
 title: "The Imperative of Inclusion"
 date: 2020-09-08
-authors: [
+author: [
   "bbcoi"
 ]
 tags: [


### PR DESCRIPTION
The Ananke theme's templates reference `.Params.author` (singular), however article frontmatter was using `authors` (plural). As a result, the author data was never surfaced in the rendered output.

  Changes:
  - Renamed `authors` to `author` in frontmatter across in `content/posts/`, `content/framework/`, and `content/about/`
