### PR TITLE
Remove generic author from posts

### DIFF
--- a/archetypes/about.md
+++ b/archetypes/about.md
@@ -2,7 +2,6 @@
 title: "{{ replace .Name "=" " " | title }}"
 date: {{ .Date }}
 author: [
-  "bbcoi"
 ]
 tags: [
   "about", "policy"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "Bug Bounty Community of Interest"
 tags: [
-  "bbcoi"
 ]
 ---
 

--- a/content/about/about-us.md
+++ b/content/about/about-us.md
@@ -2,7 +2,6 @@
 title: "About Us"
 date: 2020-01-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "about", "policy"

--- a/content/about/charter.md
+++ b/content/about/charter.md
@@ -2,7 +2,6 @@
 title: "Charter"
 date: 2020-01-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "about", "policy", "charter", "membership"

--- a/content/about/meeting-log.md
+++ b/content/about/meeting-log.md
@@ -2,7 +2,6 @@
 title: "Meeting Log"
 date: 2020-01-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "social", "meeting", "discussion", "presentation", "speakers", "notes", "log", "about", "policy"

--- a/content/about/membership-pledge.md
+++ b/content/about/membership-pledge.md
@@ -2,7 +2,6 @@
 title: "Membership Pledge"
 date: 2025-07-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "pledge", "about", "policy", "membership"

--- a/content/about/non-disclosure-agreement.md
+++ b/content/about/non-disclosure-agreement.md
@@ -2,7 +2,6 @@
 title: "Non-Disclosure Agreement"
 date: 2025-08-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "pledge", "about", "policy", "membership", "nda"

--- a/content/about/privacy-policy.md
+++ b/content/about/privacy-policy.md
@@ -2,7 +2,6 @@
 title: "Privacy Policy"
 date: 2020-01-01
 author: [
-  "bbcoi"
 ]
 tags: [
   "about", "privacy", "policy", "legal"

--- a/content/posts/ai-in-bug-bounty-platforms-evolution-or-exploitation.md
+++ b/content/posts/ai-in-bug-bounty-platforms-evolution-or-exploitation.md
@@ -2,7 +2,6 @@
 title: "AI in Bug Bounty Platforms: Evolution or Exploitation?"
 date: 2025-09-26
 author: [
-  "bbcoi"
   ]
 tags: [
   "AI Ethics", 

--- a/content/posts/call-a-duck-a-duck-not-a-bug-bounty.md
+++ b/content/posts/call-a-duck-a-duck-not-a-bug-bounty.md
@@ -2,7 +2,6 @@
 title: "Call a Duck a Duck, not a Bug Bounty"
 date: 2020-09-28
 author: [
-  "bbcoi"
 ]
 tags: [
   "bug bounty",

--- a/content/posts/effective-communication-goes-a-long-way.md
+++ b/content/posts/effective-communication-goes-a-long-way.md
@@ -2,7 +2,6 @@
 title: "Effective Communication Goes a Long Way"
 date: 2020-12-10
 author: [
-  "bbcoi"
 ]
 tags: [
   "communication",

--- a/content/posts/response-practitioners-take-on-econ.md
+++ b/content/posts/response-practitioners-take-on-econ.md
@@ -3,7 +3,6 @@ title: "Response: A Practitioner’s Take on Economic Taxonomy of Vulnerabilitie
 date: 2026-02-09
 draft: false
 author: [
-  “bbcoi”,
   "Chris Holt",
   "Marc Druzin"
 ]

--- a/content/posts/the-imperative-of-inclusion.md
+++ b/content/posts/the-imperative-of-inclusion.md
@@ -2,7 +2,6 @@
 title: "The Imperative of Inclusion"
 date: 2020-09-08
 author: [
-  "bbcoi"
 ]
 tags: [
   "inclusion",


### PR DESCRIPTION
Follow-up from https://github.com/bugbountycoi/blog/pull/17 - we have several posts that utilized a generic author name. This removes those placeholder values. 